### PR TITLE
Build fix for Qt < 6.5 on Linux

### DIFF
--- a/cmake/devtools_qt_helper.cmake
+++ b/cmake/devtools_qt_helper.cmake
@@ -73,11 +73,18 @@ if (Qt6_DIR)
                     )")
         else()
             # Generate deployment script of Qt binaries and plugins
-            qt_generate_deploy_app_script(TARGET ${PROJECT_NAME}
-                OUTPUT_SCRIPT deploy_script
-                NO_UNSUPPORTED_PLATFORM_ERROR
-                NO_TRANSLATIONS
+            if (QT_VERSION_MAJOR EQUAL 6 AND QT_VERSION_MINOR GREATER_EQUAL 5)
+                qt_generate_deploy_app_script(TARGET ${PROJECT_NAME}
+                        OUTPUT_SCRIPT deploy_script
+                        NO_UNSUPPORTED_PLATFORM_ERROR
+                        NO_TRANSLATIONS
+                )
+            else()
+                qt_generate_deploy_app_script(TARGET ${PROJECT_NAME}
+                        FILENAME_VARIABLE deploy_script
+                        NO_UNSUPPORTED_PLATFORM_ERROR
             )
+            endif()
         endif()
 
         install(SCRIPT ${deploy_script} COMPONENT ${component})


### PR DESCRIPTION
Qt versions prior to 6.5 used a different set of arguments for qt_generate_deploy_app_script() so set the appropriate arguments based on the version.

I came across this while building the project on a distro based on Debian bookwork which is shipping 6.4.2 at the time of writing: https://packages.debian.org/bookworm/qt6-base-dev

The deprecation happened in https://codereview.qt-project.org/c/qt/qtbase/+/454236